### PR TITLE
Fix dependencies expansion: handle active and auto_install keywords c…

### DIFF
--- a/click_odoo_contrib/initdb.py
+++ b/click_odoo_contrib/initdb.py
@@ -108,7 +108,7 @@ def _walk(top, exclude_patterns=EXCLUDE_PATTERNS):
 def addons_hash(module_names, with_demo):
     h = hashlib.sha1()
     h.update("!demo={}!".format(int(bool(with_demo))).encode("utf8"))
-    for module_name in sorted(expand_dependencies(module_names, True, True)):
+    for module_name in sorted(expand_dependencies(module_names, True)):
         module_path = odoo.modules.get_module_path(module_name)
         h.update(module_name.encode("utf8"))
         for filepath in _walk(module_path):

--- a/newsfragments/93.bugfix
+++ b/newsfragments/93.bugfix
@@ -1,0 +1,3 @@
+Fix dependencies expansion: handle active=True correctly
+`active=True` in a module's manifest is a deprecated equivalent to `auto_install=True`,
+so we should handle that key the same way we handle the `auto_install` one.

--- a/tests/test_manifest.py
+++ b/tests/test_manifest.py
@@ -50,6 +50,16 @@ def test_manifest_expand_dependencies_auto_install():
     assert "base_import" in res  # base_import is indirect autoinstall
 
 
+def test_manifest_expand_dependencies_no_active():
+    res = manifest.expand_dependencies(["mail"], include_auto_install=True)
+    assert "mail" in res
+    assert "base" in res  # obviously
+    assert "web" in res  # web is autoinstall
+    assert "base_import" in res  # base_import is indirect autoinstall
+    assert "l10n_fi" not in res  # is active
+    assert "account" not in res  # is dependency of account
+
+
 def test_manifest_expand_dependencies_not_found():
     with pytest.raises(manifest.ModuleNotFound):
         manifest.expand_dependencies(["not_a_module"])


### PR DESCRIPTION
…orrectly

According to the updated documentation, active=True in a module's manifest is a deprecated equivalent to auto_install=True: https://github.com/odoo/odoo/commit/2cc7f0dd49a6be1920cef232e6c010fbafa68270#diff-367842087e68d6811cf53f2ab3eb21103cd8e793b1648ef3e57f220ee0ccde4eL345 https://www.odoo.com/documentation/15.0/developer/reference/backend/module.html

it does not mean that Odoo installs it automatically, as mentioned in https://github.com/acsone/click-odoo-contrib/pull/9

OTOH, currently Odoo ignores it. See:
https://github.com/odoo/odoo/blob/13.0/odoo/modules/module.py#L335 https://github.com/odoo/odoo/blob/13.0/odoo/modules/module.py#L370

So, we should ignore that key.

Besides, this implements the more complex functionality of defining auto_install as a subset of the module's dependencies, as also explained in the documentation.

Also, add a new simple test for this case.